### PR TITLE
Refactor data model and VC to use Question enum

### DIFF
--- a/SimpleJournalApp.xcodeproj/project.pbxproj
+++ b/SimpleJournalApp.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		D6B58AEC293276AA00A89B19 /* K.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B58AEB293276AA00A89B19 /* K.swift */; };
 		D6B58AEE2932919800A89B19 /* Preferenes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B58AED2932919800A89B19 /* Preferenes.swift */; };
 		D6D827B7294CB038005AF563 /* EntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D827B6294CB038005AF563 /* EntryViewController.swift */; };
+		D6E04BF82989AB1100AA26BD /* Question.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E04BF72989AB1100AA26BD /* Question.swift */; };
 		D6E8D6312958DE9300433DCB /* Answer+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E8D62D2958DE9300433DCB /* Answer+CoreDataClass.swift */; };
 		D6E8D6322958DE9300433DCB /* Answer+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E8D62E2958DE9300433DCB /* Answer+CoreDataProperties.swift */; };
 		D6E8D6332958DE9300433DCB /* DayLog+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E8D62F2958DE9300433DCB /* DayLog+CoreDataClass.swift */; };
@@ -86,6 +87,7 @@
 		D6B58AEB293276AA00A89B19 /* K.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K.swift; sourceTree = "<group>"; };
 		D6B58AED2932919800A89B19 /* Preferenes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preferenes.swift; sourceTree = "<group>"; };
 		D6D827B6294CB038005AF563 /* EntryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryViewController.swift; sourceTree = "<group>"; };
+		D6E04BF72989AB1100AA26BD /* Question.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Question.swift; sourceTree = "<group>"; };
 		D6E8D62D2958DE9300433DCB /* Answer+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Answer+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D6E8D62E2958DE9300433DCB /* Answer+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Answer+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		D6E8D62F2958DE9300433DCB /* DayLog+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DayLog+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 				D6E8D6302958DE9300433DCB /* DayLog+CoreDataProperties.swift */,
 				D669ECC22974474100C7CC2A /* CoreDataStack.swift */,
 				D6965A6D297F03A400199EC7 /* JournalManager.swift */,
+				D6E04BF72989AB1100AA26BD /* Question.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -363,6 +366,7 @@
 				D63F453329216CCC008598C9 /* QuestionCell.swift in Sources */,
 				D669ECC32974474100C7CC2A /* CoreDataStack.swift in Sources */,
 				D6B58AEC293276AA00A89B19 /* K.swift in Sources */,
+				D6E04BF82989AB1100AA26BD /* Question.swift in Sources */,
 				D63D6BF6293BA0310092E446 /* Model.xcdatamodeld in Sources */,
 				D6D827B7294CB038005AF563 /* EntryViewController.swift in Sources */,
 				D6B43025291FB0B500E9C791 /* SceneDelegate.swift in Sources */,

--- a/SimpleJournalApp/Controllers/EntryViewController.swift
+++ b/SimpleJournalApp/Controllers/EntryViewController.swift
@@ -29,7 +29,7 @@ class EntryViewController: UIViewController {
             }
         
             if unwrappedDayLog.answers?.allObjects == nil {
-                for question in K.questions {
+                for question in Question.allCases {
                     let answer = Answer()
                     answer.question = question
                     answer.dayLog = unwrappedDayLog
@@ -48,7 +48,7 @@ class EntryViewController: UIViewController {
     //  MARK: UI elements declarations
     private let questionViews: [QuestionView] = {
         var views: [QuestionView] = []
-        for question in K.questions {
+        for question in Question.allCases {
             let view = QuestionView(frame: .zero)
             view.translatesAutoresizingMaskIntoConstraints = false
 //            view.configure(question: question)
@@ -118,7 +118,7 @@ class EntryViewController: UIViewController {
         
         if let log = dayLog {
             for view in questionViews {
-                journalManager.addAnswer(to: log, for: view.question!, text: view.returnAnswer())
+                journalManager.addAnswer(to: log, for: view.question ?? .summary, text: view.returnAnswer())
             }
         }
         
@@ -180,27 +180,37 @@ class EntryViewController: UIViewController {
     }
 
     func populate(_ answers: [Answer]) {
-        // This probably needs to be extraxted to seperate method
-        // enumerate thorugh all question views
-        for (i, view) in questionViews.enumerated() {
-            // for question view, get question from k.questions
-            // set question for the question view
-            view.question = K.questions[i]
-            // enumerate though all answers
-            for answer in answers {
-                if let question = answer.question {
-                    // If question in answer matches question for view
-                    if question == view.question {
-                        //Check if question has an answer text
-                        if let text = answer.text {
-                            // set answer in text field
-                            view.textView.text = text
-                        }
-                    }
-                }
-            }
+        
+        for (i, questionString) in Question.allCases.enumerated() {
+            questionViews[i].question = questionString
+            questionViews[i].textView.text = answers.first(where: { $0.question == questionString })?.text
             
         }
+        
+        
+        
+        
+        
+        // enumerate thorugh all question views
+//        for (i, view) in questionViews.enumerated() {
+//            // for question view, get question from k.questions
+//            // set question for the question view
+//            view.question = K.questions[i]
+//            // enumerate though all answers
+//            for answer in answers {
+//                if let Question.allCases[i] = answer.question {
+//                    // If question in answer matches question for view
+//                    if question == view.question {
+//                        //Check if question has an answer text
+//                        if let text = answer.text {
+//                            // set answer in text field
+//                            view.textView.text = text
+//                        }
+//                    }
+//                }
+//            }
+//
+//        }
     }
 }
 

--- a/SimpleJournalApp/Controllers/HistoryViewController.swift
+++ b/SimpleJournalApp/Controllers/HistoryViewController.swift
@@ -121,7 +121,7 @@ extension HistoryViewController: UITableViewDelegate, UITableViewDataSource {
                 
                 for answer in answers {
                     
-                    if answer.question == K.questions[0] {
+                    if answer.question == Question.summary {
                         if let unwrappedText = answer.text {
                             cell.configureCell(date: dateString, summary: unwrappedText)
                         } else {

--- a/SimpleJournalApp/K.swift
+++ b/SimpleJournalApp/K.swift
@@ -39,13 +39,7 @@ struct K {
         "How can I improve on that?",
         "Where was my discipline and self-control tested?"
     ]
-    enum QuestionEnum: String, CaseIterable {
-        case summary = "Summary of the day"
-        case good = "What did i do good?"
-        case bad = "What did i do bad?"
-        case improve = "How can I improve on that?"
-        case tested = "Where was my discipline and self-control tested?"
-    }
+    
     struct SFSymbols {
         static let edit = "square.and.pencil"
     }

--- a/SimpleJournalApp/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/SimpleJournalApp/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21512" systemVersion="22A400" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Answer" representedClassName=".Answer" syncable="YES">
-        <attribute name="question" optional="YES" attributeType="String"/>
-        <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="questionValue" attributeType="String" defaultValueString=""/>
+        <attribute name="text" attributeType="String"/>
         <relationship name="dayLog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DayLog" inverseName="answers" inverseEntity="DayLog"/>
     </entity>
     <entity name="DayLog" representedClassName=".DayLog" syncable="YES">

--- a/SimpleJournalApp/Model/Answer+CoreDataProperties.swift
+++ b/SimpleJournalApp/Model/Answer+CoreDataProperties.swift
@@ -15,11 +15,21 @@ extension Answer {
     @nonobjc public class func fetchRequest() -> NSFetchRequest<Answer> {
         return NSFetchRequest<Answer>(entityName: "Answer")
     }
-
-    @NSManaged public var question: String?
     @NSManaged public var text: String?
     @NSManaged public var dayLog: DayLog?
-
+    
+    @NSManaged fileprivate var questionValue: String
+    
+    public var question: Question {
+        get {
+            return Question(rawValue: questionValue) ?? .summary
+        }
+        set {
+            questionValue = newValue.rawValue
+        }
+    }
+    
+    
 }
 
 extension Answer : Identifiable {

--- a/SimpleJournalApp/Model/JournalManager.swift
+++ b/SimpleJournalApp/Model/JournalManager.swift
@@ -57,6 +57,7 @@ extension JournalManager {
         return dayLog
     }
     
+    //TODO: add update entry function??
     func updateEntry(for date: Date, with dayLog: DayLog){
         
     }
@@ -236,7 +237,7 @@ extension JournalManager {
         return nil
     }
     
-    func addAnswer(to dayLog: DayLog, for question: String, text: String, updateExistingAnswers: Bool = true) {
+    func addAnswer(to dayLog: DayLog, for question: Question, text: String, updateExistingAnswers: Bool = true) {
         //TODO: add parameter to recognize when updating answer is wanted or to create a second answer
         if updateExistingAnswers == true {
             let existingAnswers = dayLog.answers?.allObjects as! [Answer]

--- a/SimpleJournalApp/Model/JournalManager.swift
+++ b/SimpleJournalApp/Model/JournalManager.swift
@@ -32,6 +32,10 @@ public final class JournalManager {
 }
 
 extension JournalManager {
+    
+    /// Add entry for a specific date and return it - if a entry for a date already exists, return existing dayLog
+    /// - Parameter date: date for the DayLog
+    /// - Returns: created or retrived DayLog
     func addEntry(_ date: Date) -> DayLog {
         var dayLog: DayLog!
         let results = getEntry(for: date)
@@ -55,11 +59,6 @@ extension JournalManager {
             print("error occured: \(error), \(error.userInfo)")
         }
         return dayLog
-    }
-    
-    //TODO: add update entry function??
-    func updateEntry(for date: Date, with dayLog: DayLog){
-        
     }
     
     func deleteEntry(for date: Date) {

--- a/SimpleJournalApp/Model/Question.swift
+++ b/SimpleJournalApp/Model/Question.swift
@@ -1,0 +1,19 @@
+//
+//  Question.swift
+//  SimpleJournalApp
+//
+//  Created by Tomasz Kubiak on 1/31/23.
+//
+
+import Foundation
+
+
+public enum Question: String, CaseIterable {
+    case summary = "Summary of the day"
+    case good = "What did i do good?"
+    case bad = "What did i do bad?"
+    case improve = "How can I improve on that?"
+    case tested = "Where was my discipline and self-control tested?"
+}
+
+

--- a/SimpleJournalApp/Views/QuestionView.swift
+++ b/SimpleJournalApp/Views/QuestionView.swift
@@ -10,9 +10,9 @@ import UIKit
 class QuestionView: UIView {
     
     
-    var question: String? {
+    var question: Question? {
         didSet {
-            questionLabel.text = question
+            questionLabel.text = question?.rawValue
         }
     }
     var answer: String? {
@@ -68,7 +68,7 @@ class QuestionView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func configure(question: String, answer: String? = nil) {
+    func configure(question: Question, answer: String? = nil) {
         self.question = question
         self.answer = answer
     }

--- a/SimpleJournalAppTests/JournalManagerTests.swift
+++ b/SimpleJournalAppTests/JournalManagerTests.swift
@@ -58,7 +58,7 @@ extension JournalManagerTests {
         let date = Date()
         let dayLog = journalManager.addEntry(date)
         
-        let question = "This is question"
+        let question = Question.summary
         let text = "This is answer"
         journalManager.addAnswer(to: dayLog, for: question, text: text)
 //        journalManager.addAnswer(to: dayLog, for: question, answer: text)
@@ -73,7 +73,7 @@ extension JournalManagerTests {
         let date = Date()
         let dayLog = journalManager.addEntry(date)
         
-        let question = "This is question"
+        let question = Question.good
         let text = "This is answer"
         let updatedText = "This is updated answer"
         
@@ -83,7 +83,7 @@ extension JournalManagerTests {
         XCTAssertNotNil(dayLog.answers?.allObjects.first, "Answer in day log should not be nil")
         XCTAssertNotNil((dayLog.answers?.allObjects.first as? Answer)?.question, "Question in answer in day log should not be nil")
         XCTAssertNotNil((dayLog.answers?.allObjects.first as? Answer)?.text, "Text in answer in day log should not be nil")
-        XCTAssertTrue((dayLog.answers?.allObjects.first as? Answer)?.question == question, "Question should be 'This is question'")
+        XCTAssertTrue((dayLog.answers?.allObjects.first as? Answer)?.question == question, "Question should be Question.good")
         XCTAssertTrue((dayLog.answers?.allObjects.first as? Answer)?.text == updatedText, "Answer text property should be 'This is updated answer'")
     
     }
@@ -116,7 +116,7 @@ extension JournalManagerTests {
         XCTAssertTrue(resultsFromGet.error as? JournalManagerNSError == JournalManagerNSError.noResultsRetrived , "Error should be no results retrived")
         
     }
-    
+    // TODO: Rework test - add entry now covers the test when multiple entries are retrived and is fail safe
     func testGetEntryForDateWhenMultipleEntries() {
         
         let date = Date()
@@ -125,9 +125,9 @@ extension JournalManagerTests {
         
         let results = journalManager.getEntry(for: date)
         
-        XCTAssertNotNil(results.error, "Retrived results should have error")
-        XCTAssertTrue(results.dayLogs.count == 2, "Retrived day logs should have 2 entries")
-        XCTAssertTrue(results.error as? JournalManagerNSError == JournalManagerNSError.multipleResultsRetrived, "Error should be multiple results retrived")
+        XCTAssertNil(results.error, "Retrived results should not have error")
+        XCTAssertTrue(results.dayLogs.count == 1, "Retrived day logs should have 1 entry")
+        
         
         
     }


### PR DESCRIPTION
The app used to save pre defined questions in simple string data type. It made the code prone to errors and the comparision to update UI with right answers dificult and with poor performance. 

A custom enum was created to safe guard against using improper string or mis matching question answer with answer to different question. 

VCs and model were updated, as well as test in JournalManagerTests